### PR TITLE
Add cors origin env var

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -62,6 +62,7 @@ pipeline:
       - DEV_SESSION_SECRET
       - DEV_PRIVATE_POSTGREST_NAME
       - DEV_WHITELIST
+      - DEV_CORS_ORIGIN
     commands:
       - export NAME=$${DEV_NAME}
       - export KUBE_NAMESPACE=$${DEV_KUBE_NAMESPACE}
@@ -86,6 +87,7 @@ pipeline:
       - export SESSION_SECRET=$${DEV_SESSION_SECRET}
       - export PRIVATE_POSTGREST_NAME=$${DEV_PRIVATE_POSTGREST_NAME}
       - export WHITELIST=$${DEV_WHITELIST}
+      - export CORS_ORIGIN=$${DEV_CORS_ORIGIN}
       - export IMAGE_TAG=${DRONE_BUILD_NUMBER}
       - kd --insecure-skip-tls-verify -f kube/network-policy.yml
       - kd --insecure-skip-tls-verify -f kube/secret.yml
@@ -123,6 +125,7 @@ pipeline:
       - TEST_SESSION_NAME
       - TEST_SESSION_SECRET
       - TEST_PRIVATE_POSTGREST_NAME
+      - TEST_CORS_ORIGIN
     commands:
       - export NAME=$${TEST_NAME}
       - export KUBE_NAMESPACE=$${TEST_KUBE_NAMESPACE}
@@ -146,6 +149,7 @@ pipeline:
       - export SESSION_NAME=$${TEST_SESSION_NAME}
       - export SESSION_SECRET=$${TEST_SESSION_SECRET}
       - export PRIVATE_POSTGREST_NAME=$${TEST_PRIVATE_POSTGREST_NAME}
+      - export CORS_ORIGIN=$${TEST_CORS_ORIGIN}
       - export IMAGE_TAG=${DRONE_BUILD_NUMBER}
       - kd --insecure-skip-tls-verify -f kube/network-policy.yml
       - kd --insecure-skip-tls-verify -f kube/secret.yml
@@ -182,6 +186,7 @@ pipeline:
       - DEMO_SESSION_NAME
       - DEMO_SESSION_SECRET
       - DEMO_PRIVATE_POSTGREST_NAME
+      - DEMO_CORS_ORIGIN
     commands:
       - export NAME=$${DEMO_NAME}
       - export KUBE_NAMESPACE=$${DEMO_KUBE_NAMESPACE}
@@ -205,6 +210,7 @@ pipeline:
       - export SESSION_NAME=$${DEMO_SESSION_NAME}
       - export SESSION_SECRET=$${DEMO_SESSION_SECRET}
       - export PRIVATE_POSTGREST_NAME=$${DEMO_PRIVATE_POSTGREST_NAME}
+      - export CORS_ORIGIN=$${DEMO_CORS_ORIGIN}
       - export IMAGE_TAG=$${IMAGE_TAG}
       - kd --insecure-skip-tls-verify -f kube/network-policy.yml
       - kd --insecure-skip-tls-verify -f kube/secret.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       PRIVATE_WORKFLOW_ENGINE_NAME: ${PRIVATE_WORKFLOW_ENGINE_NAME}
       PRIVATE_UI_NAME: ${PRIVATE_UI_NAME}
       EXT_DOMAIN: ${EXT_DOMAIN}
+      CORS_ORIGIN: ${CORS_ORIGIN}
     volumes:
       - ${PWD}/platform/ca-bundle.crt:/etc/ssl/certs/ca-bundle.crt
       - ${PWD}/platform/mobileid-key.pem:/enccerts/mobileid-key.pem

--- a/kube/deployment.yml
+++ b/kube/deployment.yml
@@ -162,6 +162,8 @@ spec:
           value: {{.PRIVATE_UI_NAME}}
         - name: EXT_DOMAIN
           value: {{.EXT_DOMAIN}}
+        - name: CORS_ORIGIN
+          value: {{.CORS_ORIGIN}}
       volumes:
       - name: bundle
         configMap:

--- a/src/config/appConfig.js
+++ b/src/config/appConfig.js
@@ -7,6 +7,7 @@ const {
     PRIVATE_WORKFLOW_ENGINE_NAME,
     PRIVATE_UI_NAME,
     EXT_DOMAIN,
+    CORS_ORIGIN
 } = process.env;
 
 const appConfig = {
@@ -32,6 +33,9 @@ const appConfig = {
     },
     privateKey: {
        path: process.env.PRIVATE_KEY_PATH || '/enccerts/mobileid-key.pem'
+    },
+    cors: {
+        origin: CORS_ORIGIN
     }
 };
 module.exports = appConfig;

--- a/src/config/appConfig.js
+++ b/src/config/appConfig.js
@@ -25,7 +25,7 @@ const appConfig = {
             url: `${PROTOCOL}${PRIVATE_FORM_NAME}.${INT_DOMAIN}`,
         },
         referenceData: {
-            url: `${PRIVATE_REFDATA_URL}`,
+            url: `${PRIVATE_REFDATA_URL}/v1/entities`,
         },
         privateUi: {
             url: `${PROTOCOL}${PRIVATE_UI_NAME}.${EXT_DOMAIN}`,

--- a/src/index.js
+++ b/src/index.js
@@ -67,10 +67,12 @@ app.use(helmet());
 app.use(keycloak.middleware());
 app.use(Tracing.middleware);
 
-app.use(cors({
-    origin: appConfig.services.privateUi.url,
-    optionsSuccessStatus: 200
-}));
+if (appConfig.cors.origin) {
+    app.use(cors({
+        origin: JSON.parse(appConfig.cors.origin),
+        optionsSuccessStatus: 200
+    }));
+}
 
 app.use('/api/translation', route.allApiRouter(keycloak, new FormDataResolveController(translator)));
 


### PR DESCRIPTION
- Added env var for CORS origin

- Added `/v1/entities` to the reference data url so we can have just the hostname in the env var