### PR TITLE
Add FilterComponentVisitor

### DIFF
--- a/src/form/FilterComponentVisitor.js
+++ b/src/form/FilterComponentVisitor.js
@@ -1,0 +1,15 @@
+export default class FilterComponentVisitor {
+
+    constructor(jsonPathEvaluator) {
+        this.jsonPathEvaluator = jsonPathEvaluator;
+    }
+
+    visit(formComponent) {
+        const {component, dataContext} = formComponent;
+        const key = component.key;
+        if (component.filter) {
+            const value = component.filter;
+            component.filter = this.jsonPathEvaluator.performJsonPathEvaluation({key, value}, dataContext);
+        }
+    }
+}

--- a/src/form/FormComponentVisitor.js
+++ b/src/form/FormComponentVisitor.js
@@ -4,6 +4,7 @@ import CustomPropertiesVisitor from "./CustomPropertiesVisitor";
 import DefaultValueComponentVisitor from "./DefaultValueComponentVisitor";
 import PropertiesVisitor from "./PropertiesVisitor";
 import FileStorageComponentVisitor from "./FileStorageComponentVisitor";
+import FilterComponentVisitor from "./FilterComponentVisitor";
 
 export default class FormComponentVisitor {
     constructor(jsonPathEvaluator, dataDecryptor) {
@@ -13,6 +14,7 @@ export default class FormComponentVisitor {
         this.defaultValueVisitor = new DefaultValueComponentVisitor(jsonPathEvaluator);
         this.propertiesVisitor = new PropertiesVisitor(jsonPathEvaluator);
         this.fileStorageComponentVisitor = new FileStorageComponentVisitor();
+        this.filterComponentVisitor = new FilterComponentVisitor(jsonPathEvaluator);
     }
 
     visit(formComponent) {
@@ -20,6 +22,7 @@ export default class FormComponentVisitor {
         formComponent.accept(this.propertiesVisitor);
         formComponent.accept(this.defaultValueVisitor);
         formComponent.accept(this.customPropertiesVisitor);
+        formComponent.accept(this.filterComponentVisitor);
         if (component.type === 'content') {
             formComponent.accept(this.contentComponentVisitor);
         }

--- a/test/form/FilterComponentVisitor.test.js
+++ b/test/form/FilterComponentVisitor.test.js
@@ -1,0 +1,40 @@
+import FilterComponentVisitor from '../../src/form/FilterComponentVisitor'
+import {expect} from '../setUpTests'
+import JsonPathEvaluator from '../../src/form/JsonPathEvaluator';
+
+describe('FilterComponentVisitor', () => {
+    describe('visit()', () => {
+        const formComponent = {
+            component: {
+                key: 'teammembers'
+            },
+            dataContext: {
+                shiftDetailsContext: {
+                    staffid: 'cd2a2hd1-98a8-4a8a-2de8-7cbd19371438'
+                }
+            }
+        };
+        const jsonPathEvaluator = new JsonPathEvaluator();
+
+        it('should return the correct value when a json path is given', () => {
+            formComponent.component.filter = 'arglinemanagerid={$.shiftDetailsContext.staffid}';
+            const filterComponentVisitor = new FilterComponentVisitor(jsonPathEvaluator);
+            filterComponentVisitor.visit(formComponent);
+            expect(formComponent.component.filter).to.equal('arglinemanagerid=cd2a2hd1-98a8-4a8a-2de8-7cbd19371438');
+        });
+
+        it('should return the correct value when a json path is not given', () => {
+            formComponent.component.filter = 'islinemanager=true';
+            const filterComponentVisitor = new FilterComponentVisitor(jsonPathEvaluator);
+            filterComponentVisitor.visit(formComponent);
+            expect(formComponent.component.filter).to.equal('islinemanager=true');
+        });
+
+        it('should return a component without a filter property if a filter property does not exist', () => {
+            delete formComponent.component.filter;
+            const filterComponentVisitor = new FilterComponentVisitor(jsonPathEvaluator);
+            filterComponentVisitor.visit(formComponent);
+            expect(formComponent.component).to.not.have.property('filter');
+        });
+    });
+});


### PR DESCRIPTION
Add `FilterComponentVisitor` to replace tokens with data in the `Filter Query` field.

For example, we can change:

`arglinemanagerid={$.shiftDetailsContext.staffid}`

to:

`arglinemanagerid=cd2a2hd1-98a8-4a8a-2de8-7cbd19371438`

