### PR TITLE
Fix integrity leads

### DIFF
--- a/src/services/DataContextFactory.js
+++ b/src/services/DataContextFactory.js
@@ -40,8 +40,11 @@ export default class DataContextFactory {
         }
 
         if (staffDetails) {
-            const integrityLeadEmail = await this.platformDataService.getIntegrityLeadEmails(staffDetails.branchId, headers);
-            extendedStaffDetailsContext = new ExtendedStaffDetailsContext(extendedStaffDetails, integrityLeadEmail);
+            const teams = await this.platformDataService.getTeams(headers);
+            const staffTeam = teams.filter(team => team.id === staffDetails.defaultteamid)[0];
+            const teamIds = teams.filter(team => team.branchid === staffTeam.branchid).map(team => team.id).join();
+            const integrityLeadEmails = await this.platformDataService.getIntegrityLeadEmails(teamIds, headers);
+            extendedStaffDetailsContext = new ExtendedStaffDetailsContext(extendedStaffDetails, integrityLeadEmails);
         }
 
         if (taskId && processInstanceId) {

--- a/src/services/PlatformDataService.js
+++ b/src/services/PlatformDataService.js
@@ -69,15 +69,18 @@ export default class PlatformDataService {
 
     }
 
-    async getIntegrityLeadEmails(branchId, headers)  {
+    async getIntegrityLeadEmails(teamIds, headers)  {
         try {
             const response = await axios({
-                url: `${this.config.services.operationalData.url}/v1/view_rolemembers?select=email&rolelabel=eq.bfint,&branchid=eq.${branchId}`,
-                method: 'GET',
-                headers: headers
+                url: `${this.config.services.operationalData.url}/v1/rpc/rolemembers`,
+                method: 'POST',
+                headers: headers,
+                data: {
+                    argteamids: teamIds,
+                    argrolelabel: 'bfint'
+                }
             });
             const integrityLeadEmails = response.data ? response.data.map(val => val.email) : null;
-            logger.info(`Integrity lead emails found`, integrityLeadEmails);
             return integrityLeadEmails;
         } catch (err) {
             logger.error('Failed to get integrity lead emails ', err);
@@ -104,5 +107,17 @@ export default class PlatformDataService {
         }
     }
 
-
+    async getTeams(headers) {
+        try {
+            const teams = await axios({
+                url: `${this.config.services.referenceData.url}/v1/entities/team`,
+                method: 'GET',
+                headers: headers
+            });
+            return teams && teams.data ? teams.data : null;
+        } catch (err) {
+            logger.error('Failed to get teams ', err);
+            return null;
+        }
+    }
 }

--- a/test/controllers/formDataBusinessKey.test.js
+++ b/test/controllers/formDataBusinessKey.test.js
@@ -16,7 +16,8 @@ describe('Form Data Resolve Controller With Business Key', () => {
                 argstaffemail: "email"
             })
             .reply(200, [{
-                staffid: 'abc-123'
+                staffid: 'abc-123',
+                defaultteamid: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
             }])
             .get('/v1/shift?email=eq.email')
             .reply(200, [])
@@ -27,6 +28,10 @@ describe('Form Data Resolve Controller With Business Key', () => {
             })
             .reply(200, [{
                 linemanager_email: 'linemanager@homeoffice.gov.uk'
+            }])
+            .get('/v1/entities/team')
+            .reply(200, [{
+                id: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
             }]);
     });
 

--- a/test/controllers/formDataResolveController.test.js
+++ b/test/controllers/formDataResolveController.test.js
@@ -20,7 +20,8 @@ describe('Form Data Resolve Controller', () => {
                     argstaffemail : 'email'
                 })
                 .reply(200, [{
-                    staffid: 'abc-123'
+                    staffid: 'abc-123',
+                    defaultteamid: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
                 }])
                 .get('/v1/shift?email=eq.email')
                 .reply(200, [])
@@ -31,6 +32,10 @@ describe('Form Data Resolve Controller', () => {
                 })
                 .reply(200, [{
                     linemanager_email: 'linemanager@homeoffice.gov.uk'
+                }])
+                .get('/v1/entities/team')
+                .reply(200, [{
+                    id: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
                 }]);
         });
 

--- a/test/controllers/formDataResolveControllerIframe.test.js
+++ b/test/controllers/formDataResolveControllerIframe.test.js
@@ -45,7 +45,8 @@ describe('Form Data Resolve Controller', () => {
                     linemanager_email: 'linemanager@homeoffice.gov.uk'
                 }])
                 .post('/v1/rpc/staffdetails', {
-                    argstaffemail : 'email'
+                    argstaffemail : 'email',
+                    defaultteamid: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
                 })
                 .reply(200, [{
                     staffid: 'abc-123'

--- a/test/controllers/formDataResolveControllerImg.test.js
+++ b/test/controllers/formDataResolveControllerImg.test.js
@@ -51,7 +51,12 @@ describe('Form Data Resolve Controller', () => {
                     argstaffemail : 'email'
                 })
                 .reply(200, [{
-                    staffid: 'abc-123'
+                    staffid: 'abc-123',
+                    defaultteamid: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
+                }])
+                .get('/v1/entities/team')
+                .reply(200, [{
+                    id: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
                 }]);
         });
 

--- a/test/controllers/formDataResolveControllerShift.test.js
+++ b/test/controllers/formDataResolveControllerShift.test.js
@@ -13,29 +13,28 @@ describe('Form Data Resolve Controller', () => {
                     total : 1,
                     forms: forms.shiftForm
                 });
+
             nock('http://localhost:9001')
                 .post('/v1/rpc/staffdetails', {
                     argstaffemail: 'email'
                 })
                 .reply(200, [{
-                    staffid: 'abc-123'
-                }]);
-            nock('http://localhost:9001')
+                    staffid: 'abc-123',
+                    defaultteamid: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
+                }])
                 .get('/v1/shift?email=eq.email')
                 .reply(200, [{
                     locationid: 'currentlocationid',
                     teamid: 'teamid',
                     email: 'email'
-                }]);
-            nock('http://localhost:9001')
+                }])
                 .get('/v1/entities/location?id=eq.currentlocationid')
                 .reply(200, {data: [{
                     locationname: 'Current',
                     locationid: 'currentlocationid',
                     bflocationtypeid: 'bflocationtypeid'
 
-                }]});
-            nock('http://localhost:9001')
+                }]})
                 .get('/v1/entities/bflocationtype?id=eq.bflocationtypeid')
                 .reply(200, {data: [{
                     bflocationtypeid: 'bflocationtypeid',
@@ -54,6 +53,10 @@ describe('Form Data Resolve Controller', () => {
                 })
                 .reply(200, [{
                     linemanager_email: 'linemanager@homeoffice.gov.uk'
+                }])
+                .get('/v1/entities/team')
+                .reply(200, [{
+                    id: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
                 }]);
         });
 

--- a/test/controllers/formDataResolveEncryptionController.test.js
+++ b/test/controllers/formDataResolveEncryptionController.test.js
@@ -12,20 +12,18 @@ describe('Form Data Controller', () => {
             .reply(200, {
                 total : 1,
                 forms: forms.encryptedImgForm
-            });
-        nock('http://localhost:8000')
+            })
             .get('/form?name=encryptedImgFormWithMissingEncryptionTag')
             .reply(200, {
                 total: 1,
                 forms: forms.encryptedImgFormWithMissingEncryptionTag
             });
+
         nock('http://localhost:9000')
             .get('/api/workflow/tasks/taskId')
-            .reply(200, tasks.taskData);
-        nock('http://localhost:9000')
+            .reply(200, tasks.taskData)
             .get('/api/workflow/tasks/taskId/variables')
-            .reply(200, tasks.taskVariables);
-        nock('http://localhost:9000')
+            .reply(200, tasks.taskVariables)
             .get('/api/workflow/process-instances/processInstanceId/variables')
             .reply(200, tasks.processVariablesWithEncryptedFields);
 
@@ -34,9 +32,9 @@ describe('Form Data Controller', () => {
                 argstaffemail: 'email'
             })
             .reply(200, [{
-                staffid: 'abc-123'
-            }]);
-        nock('http://localhost:9001')
+                staffid: 'abc-123',
+                defaultteamid: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
+            }])
             .get('/v1/shift?email=eq.email')
             .reply(200, [])
             .post('/v1/rpc/extendedstaffdetails', {
@@ -44,6 +42,10 @@ describe('Form Data Controller', () => {
             })
             .reply(200, [{
                 linemanager_email: 'linemanager@homeoffice.gov.uk'
+            }])
+            .get('/v1/entities/team')
+            .reply(200, [{
+                id: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
             }]);
     });
 

--- a/test/controllers/formDataResolvePostController.test.js
+++ b/test/controllers/formDataResolvePostController.test.js
@@ -2,7 +2,6 @@ import JSONPath from 'jsonpath';
 import nock from 'nock';
 import httpMocks from 'node-mocks-http';
 import * as forms from '../forms'
-
 import {expect, formTranslateController} from '../setUpTests'
 
 describe('Form Data Resolve Controller', () => {
@@ -23,7 +22,8 @@ describe('Form Data Resolve Controller', () => {
                     argstaffemail: 'email'
                 })
                 .reply(200, [{
-                    staffid: 'abc-123'
+                    staffid: 'abc-123',
+                    defaultteamid: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
                 }])
                 .get('/v1/shift?email=eq.email')
                 .reply(200, [])
@@ -32,6 +32,10 @@ describe('Form Data Resolve Controller', () => {
                 })
                 .reply(200, [{
                     linemanager_email: 'linemanager@homeoffice.gov.uk'
+                }])
+                .get('/v1/entities/team')
+                .reply(200, [{
+                    id: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
                 }]);
         });
 

--- a/test/controllers/formDataResolveSimpleController.test.js
+++ b/test/controllers/formDataResolveSimpleController.test.js
@@ -19,7 +19,8 @@ describe('Form Data Resolve Controller', () => {
                     argstaffemail : 'email'
                 })
                 .reply(200, [{
-                    staffid: 'abc-123'
+                    staffid: 'abc-123',
+                    defaultteamid: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
                 }])
                 .get('/v1/shift?email=eq.email')
                 .reply(200, [])
@@ -28,6 +29,10 @@ describe('Form Data Resolve Controller', () => {
                 })
                 .reply(200, [{
                     linemanager_email: 'linemanager@homeoffice.gov.uk'
+                }])
+                .get('/v1/entities/team')
+                .reply(200, [{
+                    id: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
                 }]);
         });
 

--- a/test/controllers/formDataResolveTaskContext.test.js
+++ b/test/controllers/formDataResolveTaskContext.test.js
@@ -36,7 +36,8 @@ describe('Form Data Resolve Controller', () => {
                 argstaffemail: 'email'
             })
             .reply(200, [{
-                staffid: 'abc-123'
+                staffid: 'abc-123',
+                defaultteamid: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
             }])
             .post('/v1/rpc/extendedstaffdetails', {
                 argstaffemail: 'email'
@@ -45,7 +46,11 @@ describe('Form Data Resolve Controller', () => {
                 linemanager_email: 'linemanager@homeoffice.gov.uk'
             }])
             .get('/v1/shift?email=eq.email')
-            .reply(200, []);
+            .reply(200, [])
+            .get('/v1/entities/team')
+            .reply(200, [{
+                id: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
+            }]);
     });
 
     describe('A call to data resolve controller for process variables context', () => {

--- a/test/controllers/formDataResolveUserDetailsContext.test.js
+++ b/test/controllers/formDataResolveUserDetailsContext.test.js
@@ -32,10 +32,15 @@ describe('Form Data Resolve Controller', () => {
                     }
                 ],
                 staffid: 'staffid',
-                gradename: 'grade'
+                gradename: 'grade',
+                defaultteamid: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
             }])
             .get('/v1/shift?email=eq.staffmember@homeoffice.gov.uk')
-            .reply(200, []);
+            .reply(200, [])
+            .get('/v1/entities/team')
+            .reply(200, [{
+                id: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
+            }]);
     });
 
     describe('A call to data resolve controller for user details context', () => {

--- a/test/services/PlatformDataService.test.js
+++ b/test/services/PlatformDataService.test.js
@@ -3,27 +3,34 @@ import nock from 'nock';
 import { expect } from '../setUpTests';
 
 describe('PlatformDataService', () => {
+    const config = {
+        services: {
+            operationalData: {
+                url: 'http://localhost:9000'
+            },
+            referenceData: {
+                url: 'http://localhost:9001'
+            }
+        }
+    };
+
+    afterEach(() => {
+        nock.cleanAll();
+    });
+
     describe('getIntegrityLeadEmails', () => {
         it('should return the correct data when integrity leads are found successfully', async () => {
-            nock('http://localhost:9000', {Authorization: 'Bearer token'})
+            nock('http://localhost:9000', { Authorization: 'Bearer token' })
             .log(console.log)
-            .get('/v1/view_rolemembers?select=email&rolelabel=eq.bfint,&branchid=eq.10')
+            .post('/v1/rpc/rolemembers')
             .reply(200, [{
                 email: 'integritylead1@homeoffice.gov.uk'
             }, {
                 email: 'integritylead2@homeoffice.gov.uk'
             }]);
 
-            const config = {
-                services: {
-                    operationalData: {
-                        url: 'http://localhost:9000'
-                    }
-                }
-            };
-
             const platformDataService = new PlatformDataService(config);
-            const response = await platformDataService.getIntegrityLeadEmails(10, {Authorization: 'Bearer token'});
+            const response = await platformDataService.getIntegrityLeadEmails(10, { Authorization: 'Bearer token' });
 
             expect(response).to.deep.equal([
                 'integritylead1@homeoffice.gov.uk',
@@ -32,21 +39,47 @@ describe('PlatformDataService', () => {
         });
 
         it('should return null when an error occurs', async () => {
-            nock('http://localhost:9000', {Authorization: 'Bearer token'})
+            nock('http://localhost:9000', { Authorization: 'Bearer token' })
                 .log(console.log)
                 .get('/v1/view_rolemembers?select=email&rolelabel=eq.bfint,&branchid=eq.null')
                 .reply(500, 'Internal Server Error');
 
-            const config = {
-                services: {
-                    operationalData: {
-                        url: 'http://localhost:9000'
-                    }
-                }
-            };
+            const platformDataService = new PlatformDataService(config);
+            const response = await platformDataService.getIntegrityLeadEmails(null, { Authorization: 'Bearer token' });
+
+            expect(response).to.equal(null);
+        });
+    });
+
+    describe('getTeams', () => {
+        it('should return the correct data when teams are found successfully', async () => {
+            nock('http://localhost:9001', {Authorization: 'Bearer token'})
+            .log(console.log)
+            .get('/v1/entities/team')
+            .reply(200, [{
+                id: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
+            }, {
+                id: 'ccbf8c53-0e54-414d-ad4a-0c3edad07515'
+            }]);
 
             const platformDataService = new PlatformDataService(config);
-            const response = await platformDataService.getIntegrityLeadEmails(null, {Authorization: 'Bearer token'});
+            const response = await platformDataService.getTeams({ Authorization: 'Bearer token' });
+
+            expect(response).to.deep.equal([{
+                id: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
+            }, {
+                id: 'ccbf8c53-0e54-414d-ad4a-0c3edad07515'
+            }]);
+        });
+
+        it('should return null when an error occurs', async () => {
+            nock('http://localhost:9001', { Authorization: 'Bearer token' })
+                .log(console.log)
+                .get('/v1/entities/team')
+                .reply(500, 'Internal Server Error');
+
+            const platformDataService = new PlatformDataService(config);
+            const response = await platformDataService.getTeams({ Authorization: 'Bearer token' });
 
             expect(response).to.equal(null);
         });


### PR DESCRIPTION
Teams have been removed from the operational database so to get the integrity leads for a user we need to get the teams, filter those by the team of the user to get the branch id, then use that branch id to filter the teams to get the team ids for the branch, which are used to filter the role members.