### PR TITLE
CO-902 - Integrity Lead(s) aren't receiving emails + tasks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,19 +6,20 @@ import appConfig from './config/appConfig'
 import Redis from 'ioredis';
 import Keycloak from 'keycloak-connect';
 import helmet from 'helmet';
-import KeyRepository from "./services/KeyRepository";
-import DataDecryptor from "./services/DataDecryptor";
-import DataContextFactory from "./services/DataContextFactory";
-import PlatformDataService from "./services/PlatformDataService";
-import ProcessService from "./services/ProcessService";
-import FormTranslator from "./form/FormTranslator";
-import FormEngineService from "./services/FormEngineService";
-import FormDataResolveController from "./controllers/FormTranslateController";
-import WorkflowTranslationController from "./controllers/workflowTranslationController";
+import KeyRepository from './services/KeyRepository';
+import DataDecryptor from './services/DataDecryptor';
+import DataContextFactory from './services/DataContextFactory';
+import PlatformDataService from './services/PlatformDataService';
+import ProcessService from './services/ProcessService';
+import FormTranslator from './form/FormTranslator';
+import FormEngineService from './services/FormEngineService';
+import FormDataResolveController from './controllers/FormTranslateController';
+import WorkflowTranslationController from './controllers/workflowTranslationController';
 import logger from './config/winston';
-import Tracing from "./utilities/tracing";
+import Tracing from './utilities/tracing';
 import cors from 'cors';
-import BusinessKeyGenerator from "./services/BusinessKeyGenerator";
+import BusinessKeyGenerator from './services/BusinessKeyGenerator';
+import IntegrityLeadService from './services/IntegrityLeadService';
 
 const http = require('http');
 const fs = require('fs');
@@ -74,8 +75,20 @@ const redis = checkRedisSSL(appConfig.redis.ssl);
 
 const processService = new ProcessService(appConfig);
 const referenceGenerator = new BusinessKeyGenerator(redis);
-const dataContextFactory = new DataContextFactory(new PlatformDataService(appConfig), processService, dataDecryptor, referenceGenerator);
-const translator = new FormTranslator(new FormEngineService(appConfig), dataContextFactory, dataDecryptor);
+const platformDataService = new PlatformDataService(appConfig);
+const integrityLeadService = new IntegrityLeadService(platformDataService);
+const dataContextFactory = new DataContextFactory(
+    platformDataService,
+    processService,
+    dataDecryptor,
+    referenceGenerator,
+    integrityLeadService
+);
+const translator = new FormTranslator(
+    new FormEngineService(appConfig),
+    dataContextFactory,
+    dataDecryptor
+);
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: false}));

--- a/src/services/DataContextFactory.js
+++ b/src/services/DataContextFactory.js
@@ -1,18 +1,25 @@
-import StaffDetailsContext from "../models/StaffDetailsContext";
-import EnvironmentContext from "../models/EnvironmentContext";
-import ShiftDetailsContext from "../models/ShiftDetailsContext";
-import DataResolveContext from "../models/DataResolveContext";
+import StaffDetailsContext from '../models/StaffDetailsContext';
+import EnvironmentContext from '../models/EnvironmentContext';
+import ShiftDetailsContext from '../models/ShiftDetailsContext';
+import DataResolveContext from '../models/DataResolveContext';
 import ExtendedStaffDetailsContext from '../models/ExtendedStaffDetailsContext';
-import ProcessContext from "../models/ProcessContext";
-import TaskContext from "../models/TaskContext";
-import appConfig from "../config/appConfig";
+import ProcessContext from '../models/ProcessContext';
+import TaskContext from '../models/TaskContext';
+import appConfig from '../config/appConfig';
 
 export default class DataContextFactory {
-    constructor(platformDataService, processService, dataDecryptor, referenceGenerator) {
+    constructor(
+        platformDataService,
+        processService,
+        dataDecryptor,
+        referenceGenerator,
+        integrityLeadService
+    ) {
         this.platformDataService = platformDataService;
         this.processService = processService;
         this.dataDecryptor = dataDecryptor;
-        this.referenceGenerator = referenceGenerator
+        this.referenceGenerator = referenceGenerator;
+        this.integrityLeadService = integrityLeadService;
     }
 
     async createDataContext(keycloakContext, {processInstanceId, taskId}, customDataContext) {
@@ -40,10 +47,7 @@ export default class DataContextFactory {
         }
 
         if (staffDetails) {
-            const teams = await this.platformDataService.getTeams(headers);
-            const staffTeam = teams.filter(team => team.id === staffDetails.defaultteamid)[0];
-            const teamIds = teams.filter(team => team.branchid === staffTeam.branchid).map(team => team.id).join();
-            const integrityLeadEmails = await this.platformDataService.getIntegrityLeadEmails(teamIds, headers);
+            const integrityLeadEmails = await this.integrityLeadService.getEmails(staffDetails.defaultteamid, headers);
             extendedStaffDetailsContext = new ExtendedStaffDetailsContext(extendedStaffDetails, integrityLeadEmails);
         }
 

--- a/src/services/IntegrityLeadService.js
+++ b/src/services/IntegrityLeadService.js
@@ -1,0 +1,33 @@
+class IntegrityLeadService {
+  constructor(platformDataService) {
+    this.platformDataService = platformDataService;
+  }
+
+  async getEmails(staffTeamId, headers) {
+    const teams = await this.platformDataService.getTeams(headers);
+    const staffTeam = this.staffTeam(teams, staffTeamId);
+    const branchTeamIds = this.branchTeamIds(teams, staffTeam.branchid);
+    const integrityLeads = await this.platformDataService.getIntegrityLeads(headers);
+    return this.emails(integrityLeads, branchTeamIds);
+  }
+
+  staffTeam(teams, staffTeamId) {
+    return teams
+      .filter(team => team.id === staffTeamId)[0];
+  }
+
+  branchTeamIds(teams, staffBranchId) {
+    return teams
+      .filter(team => team.branchid === staffBranchId)
+      .map(team => team.id);
+  }
+
+  emails(integrityLeads, branchTeamIds) {
+    return integrityLeads
+      .filter(integrityLead => branchTeamIds.includes(integrityLead.defaultteamid))
+      .map(integrityLead => integrityLead.email)
+      .join();
+  }
+}
+
+export default IntegrityLeadService;

--- a/src/services/PlatformDataService.js
+++ b/src/services/PlatformDataService.js
@@ -69,21 +69,16 @@ export default class PlatformDataService {
 
     }
 
-    async getIntegrityLeadEmails(teamIds, headers)  {
+    async getIntegrityLeads(headers)  {
         try {
             const response = await axios({
-                url: `${this.config.services.operationalData.url}/v1/rpc/rolemembers`,
-                method: 'POST',
-                headers: headers,
-                data: {
-                    argteamids: teamIds,
-                    argrolelabel: 'bfint'
-                }
+                url: `${this.config.services.operationalData.url}/v2/view_rolemembers?filter=rolelabel=eq.bfint`,
+                method: 'GET',
+                headers: headers
             });
-            const integrityLeadEmails = response.data ? response.data.map(val => val.email) : null;
-            return integrityLeadEmails;
+            return response.data;
         } catch (err) {
-            logger.error('Failed to get integrity lead emails ', err);
+            logger.error('Failed to get integrity leads ', err);
             return null;
         }
     }

--- a/test/controllers/formDataBusinessKey.test.js
+++ b/test/controllers/formDataBusinessKey.test.js
@@ -21,8 +21,6 @@ describe('Form Data Resolve Controller With Business Key', () => {
             }])
             .get('/v1/shift?email=eq.email')
             .reply(200, [])
-            .get('/v1/view_rolemembers?select=email&rolelabel=eq.bfint,&branchid=eq.undefined')
-            .reply(200, [])
             .post('/v1/rpc/extendedstaffdetails', {
                 argstaffemail: 'email'
             })
@@ -34,7 +32,12 @@ describe('Form Data Resolve Controller With Business Key', () => {
                 data: [{
                     id: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
                 }]
-            });
+            })
+            .get('/v2/view_rolemembers?filter=rolelabel=eq.bfint')
+            .reply(200, [{
+                email: 'integritylead1@homeoffice.gov.uk',
+                defaultteamid: '15a13c2a-fa63-4437-b4b0-d6b070e9c17e',
+            }]);
     });
 
     it('it returns form with a newBusinessKey label and api of businessKey', async () => {

--- a/test/controllers/formDataResolveController.test.js
+++ b/test/controllers/formDataResolveController.test.js
@@ -25,8 +25,6 @@ describe('Form Data Resolve Controller', () => {
                 }])
                 .get('/v1/shift?email=eq.email')
                 .reply(200, [])
-                .get('/v1/view_rolemembers?select=email&rolelabel=eq.bfint,&branchid=eq.undefined')
-                .reply(200, [])
                 .post('/v1/rpc/extendedstaffdetails', {
                     argstaffemail: 'email'
                 })
@@ -38,7 +36,12 @@ describe('Form Data Resolve Controller', () => {
                     data: [{
                         id: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
                     }]
-                });
+                })
+                .get('/v2/view_rolemembers?filter=rolelabel=eq.bfint')
+                .reply(200, [{
+                    email: 'integritylead1@homeoffice.gov.uk',
+                    defaultteamid: '15a13c2a-fa63-4437-b4b0-d6b070e9c17e',
+                }]);
         });
 
         it('it should return an updated form schema for keycloakContext', async () => {

--- a/test/controllers/formDataResolveControllerImg.test.js
+++ b/test/controllers/formDataResolveControllerImg.test.js
@@ -59,7 +59,12 @@ describe('Form Data Resolve Controller', () => {
                     data: [{
                         id: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
                     }]
-                });
+                })
+                .get('/v2/view_rolemembers?filter=rolelabel=eq.bfint')
+                .reply(200, [{
+                    email: 'integritylead1@homeoffice.gov.uk',
+                    defaultteamid: '15a13c2a-fa63-4437-b4b0-d6b070e9c17e',
+                }]);
         });
 
         it('it should base64encode image source', async () => {

--- a/test/controllers/formDataResolveControllerShift.test.js
+++ b/test/controllers/formDataResolveControllerShift.test.js
@@ -46,8 +46,6 @@ describe('Form Data Resolve Controller', () => {
                     bordercrossing: false,
                     roadterminal: false
                 }]})
-                .get('/v1/view_rolemembers?select=email&rolelabel=eq.bfint,&branchid=eq.undefined')
-                .reply(200, [])
                 .post('/v1/rpc/extendedstaffdetails', {
                     argstaffemail: 'email'
                 })
@@ -59,7 +57,12 @@ describe('Form Data Resolve Controller', () => {
                     data: [{
                         id: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
                     }]
-                });
+                })
+                .get('/v2/view_rolemembers?filter=rolelabel=eq.bfint')
+                .reply(200, [{
+                    email: 'integritylead1@homeoffice.gov.uk',
+                    defaultteamid: '15a13c2a-fa63-4437-b4b0-d6b070e9c17e',
+                }]);
         });
 
         it('it should return an updated form schema for keycloakContext', async () => {

--- a/test/controllers/formDataResolveEncryptionController.test.js
+++ b/test/controllers/formDataResolveEncryptionController.test.js
@@ -48,7 +48,12 @@ describe('Form Data Controller', () => {
                 data: [{
                     id: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
                 }]
-            });
+            })
+            .get('/v2/view_rolemembers?filter=rolelabel=eq.bfint')
+            .reply(200, [{
+                email: 'integritylead1@homeoffice.gov.uk',
+                defaultteamid: '15a13c2a-fa63-4437-b4b0-d6b070e9c17e',
+            }]);
     });
 
     it('can decrypt value before serving', async() => {

--- a/test/controllers/formDataResolvePostController.test.js
+++ b/test/controllers/formDataResolvePostController.test.js
@@ -38,7 +38,12 @@ describe('Form Data Resolve Controller', () => {
                     data: [{
                         id: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
                     }]
-                });
+                })
+                .get('/v2/view_rolemembers?filter=rolelabel=eq.bfint')
+                .reply(200, [{
+                    email: 'integritylead1@homeoffice.gov.uk',
+                    defaultteamid: '15a13c2a-fa63-4437-b4b0-d6b070e9c17e',
+                }]);
         });
 
         it('it should return an updated form schema for custom context', async () => {

--- a/test/controllers/formDataResolveSimpleController.test.js
+++ b/test/controllers/formDataResolveSimpleController.test.js
@@ -35,7 +35,12 @@ describe('Form Data Resolve Controller', () => {
                     data: [{
                         id: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
                     }]
-                });
+                })
+                .get('/v2/view_rolemembers?filter=rolelabel=eq.bfint')
+                .reply(200, [{
+                    email: 'integritylead1@homeoffice.gov.uk',
+                    defaultteamid: '15a13c2a-fa63-4437-b4b0-d6b070e9c17e',
+                }]);
         });
 
         it('it should return form without any data resolution', async () => {

--- a/test/controllers/formDataResolveTaskContext.test.js
+++ b/test/controllers/formDataResolveTaskContext.test.js
@@ -52,7 +52,12 @@ describe('Form Data Resolve Controller', () => {
                 data: [{
                     id: '018d7442-4b4e-4ff3-acc6-f2d865a6e6ad'
                 }]
-            });
+            })
+            .get('/v2/view_rolemembers?filter=rolelabel=eq.bfint')
+            .reply(200, [{
+                email: 'integritylead1@homeoffice.gov.uk',
+                defaultteamid: '15a13c2a-fa63-4437-b4b0-d6b070e9c17e',
+            }]);
     });
 
     describe('A call to data resolve controller for process variables context', () => {

--- a/test/controllers/formDataResolveUserDetailsContext.test.js
+++ b/test/controllers/formDataResolveUserDetailsContext.test.js
@@ -48,8 +48,11 @@ describe('Form Data Resolve Controller', () => {
     describe('A call to data resolve controller for user details context', () => {
         beforeEach(() => {
             nock('http://localhost:9001')
-                .get('/v1/view_rolemembers?select=email&rolelabel=eq.bfint,&branchid=eq.undefined')
-                .reply(200, [])
+                .get('/v2/view_rolemembers?filter=rolelabel=eq.bfint')
+                .reply(200, [{
+                    email: 'integritylead1@homeoffice.gov.uk',
+                    defaultteamid: '15a13c2a-fa63-4437-b4b0-d6b070e9c17e',
+                }])
                 .post('/v1/rpc/extendedstaffdetails', {
                     argstaffemail: 'staffmember@homeoffice.gov.uk'
                 })

--- a/test/services/IntegrityLeadService.test.js
+++ b/test/services/IntegrityLeadService.test.js
@@ -1,0 +1,114 @@
+import expect from 'expect';
+import sinon from 'sinon';
+import IntegrityLeadService from '../../src/services/IntegrityLeadService';
+import PlatformDataService from '../../src/services/PlatformDataService';
+
+describe('IntegrityLeadService', () => {
+  let platformDataService;
+  let integrityLeads;
+
+  const staffTeamId = '15a13c2a-fa63-4437-b4b0-d6b070e9c17e';
+  const teams = [{
+    id: staffTeamId,
+    branchid: 11
+  }, {
+    id: '444e92aa-16e6-41fb-9642-783532f4dd84',
+    branchid: 12
+  }, {
+    id: 'bfb30c46-e7fa-4716-81b7-7687eef2c312',
+    branchid: 12
+  }];
+
+  beforeEach(() => {
+    platformDataService = sinon.createStubInstance(PlatformDataService);
+    platformDataService.getTeams.returns([{
+      id: staffTeamId,
+      branchId: 12
+    }]);
+    integrityLeads = [{
+      email: 'integritylead1@homeoffice.gov.uk',
+      defaultteamid: staffTeamId,
+    }, {
+      email: 'integritylead2@homeoffice.gov.uk',
+      defaultteamid: staffTeamId,
+    }, {
+      email: 'integritylead3@homeoffice.gov.uk',
+      defaultteamid: '9f4bebae-ffd1-4a31-9cfd-2108d3a1423f',
+    }];
+  });
+
+  describe('getEmails', () => {
+    it('should return comma delimited emails when integrity leads are found', async () => {
+      platformDataService.getIntegrityLeads.returns(integrityLeads);
+
+      const integrityLeadService = new IntegrityLeadService(platformDataService);
+      const emails = await integrityLeadService.getEmails(staffTeamId, {});
+
+      expect(emails).toEqual('integritylead1@homeoffice.gov.uk,integritylead2@homeoffice.gov.uk');
+    });
+
+    it('should return an empty string when integrity leads are not found', async () => {
+      platformDataService.getIntegrityLeads.returns([integrityLeads.pop()]);
+
+      const integrityLeadService = new IntegrityLeadService(platformDataService);
+      const emails = await integrityLeadService.getEmails(staffTeamId, {});
+
+      expect(emails).toEqual('');
+    });
+  });
+
+  describe('staffTeam', () => {
+    it('should return the correct team for a staff member', () => {
+      const integrityLeadService = new IntegrityLeadService(platformDataService);
+      const staffTeam = integrityLeadService.staffTeam(teams, staffTeamId);
+
+      expect(staffTeam).toEqual({
+        id: staffTeamId,
+        branchid: 11
+      });
+    });
+
+    it('should return undefined when a team is not found for a staff member', () => {
+      const integrityLeadService = new IntegrityLeadService(platformDataService);
+      const staffTeam = integrityLeadService.staffTeam(teams, 20);
+
+      expect(staffTeam).toEqual(undefined);
+    });
+  });
+
+  describe('branchTeamIds', () => {
+    it('should return the correct teams for a branch', () => {
+      const integrityLeadService = new IntegrityLeadService(platformDataService);
+      const branchTeamIds = integrityLeadService.branchTeamIds(teams, 12);
+
+      expect(branchTeamIds).toEqual([
+        '444e92aa-16e6-41fb-9642-783532f4dd84',
+        'bfb30c46-e7fa-4716-81b7-7687eef2c312'
+      ]);
+    });
+
+    it('should return an empty array when teams cannot be found for a branch', () => {
+      const integrityLeadService = new IntegrityLeadService(platformDataService);
+      const branchTeamIds = integrityLeadService.branchTeamIds(teams, 21);
+
+      expect(branchTeamIds).toEqual([]);
+    });
+  });
+
+  describe('emails', () => {
+    it('should return comma delimited emails for the integrity leads', () => {
+      const integrityLeadService = new IntegrityLeadService(platformDataService);
+      const emails = integrityLeadService.emails(integrityLeads, [staffTeamId]);
+
+      expect(emails).toEqual('integritylead1@homeoffice.gov.uk,integritylead2@homeoffice.gov.uk');
+    });
+
+    it('should return an empty string when integrity leads cannot be found', () => {
+      const branchTeamIds = ['2d97b103-67d3-46f9-8d1f-d7be8f90f2ec'];
+      const integrityLeadService = new IntegrityLeadService(platformDataService);
+      const emails = integrityLeadService.emails(integrityLeads, branchTeamIds);
+
+      expect(emails).toEqual('');
+    });
+  });
+});

--- a/test/services/PlatformDataService.test.js
+++ b/test/services/PlatformDataService.test.js
@@ -18,24 +18,30 @@ describe('PlatformDataService', () => {
         nock.cleanAll();
     });
 
-    describe('getIntegrityLeadEmails', () => {
+    describe('getIntegrityLeads', () => {
         it('should return the correct data when integrity leads are found successfully', async () => {
+            const integrityLeads = [{
+                staffid: "a4335c55-d7e9-49db-88e5-1acc2e6cff6c",
+                identityid: "3fca4748-0adf-4a59-ab73-386c54fe292f",
+                email: "integritylead@homeoffice.gov.uk",
+                gradeid: "ca976df5-21b5-4e46-9e3f-ebb8fbec6d70",
+                phone: "07123123456",
+                defaultteamid: "57ba6ac8-0193-47ef-9c52-ec77f7daedb5",
+                adelphi: 12345678,
+                dateofleaving: null,
+                defaultlocationid: 2,
+                onboardprocessinstanceid: null,
+                rolelabel: "bfint"
+            }];
             nock('http://localhost:9000', { Authorization: 'Bearer token' })
-            .log(console.log)
-            .post('/v1/rpc/rolemembers')
-            .reply(200, [{
-                email: 'integritylead1@homeoffice.gov.uk'
-            }, {
-                email: 'integritylead2@homeoffice.gov.uk'
-            }]);
+                .log(console.log)
+                .get('/v2/view_rolemembers?filter=rolelabel=eq.bfint')
+                .reply(200, integrityLeads);
 
             const platformDataService = new PlatformDataService(config);
-            const response = await platformDataService.getIntegrityLeadEmails(10, { Authorization: 'Bearer token' });
+            const response = await platformDataService.getIntegrityLeads({ Authorization: 'Bearer token' });
 
-            expect(response).to.deep.equal([
-                'integritylead1@homeoffice.gov.uk',
-                'integritylead2@homeoffice.gov.uk'
-            ]);
+            expect(response).to.deep.equal(integrityLeads);
         });
 
         it('should return null when an error occurs', async () => {
@@ -45,7 +51,7 @@ describe('PlatformDataService', () => {
                 .reply(500, 'Internal Server Error');
 
             const platformDataService = new PlatformDataService(config);
-            const response = await platformDataService.getIntegrityLeadEmails(null, { Authorization: 'Bearer token' });
+            const response = await platformDataService.getIntegrityLeads({ Authorization: 'Bearer token' });
 
             expect(response).to.equal(null);
         });

--- a/test/setUpTests.js
+++ b/test/setUpTests.js
@@ -8,6 +8,7 @@ import FormEngineService from "../src/services/FormEngineService";
 import DataContextFactory from "../src/services/DataContextFactory";
 import PlatformDataService from "../src/services/PlatformDataService";
 import ProcessService from "../src/services/ProcessService";
+import IntegrityLeadService from '../src/services/IntegrityLeadService';
 import FormTranslateController from "../src/controllers/FormTranslateController";
 import WorkflowTranslationController from "../src/controllers/workflowTranslationController";
 import fs from "fs";
@@ -41,9 +42,20 @@ const referenceGenerator = new BusinessKeyGenerator(mockRedis);
 
 const processService = new ProcessService(appConfig)
 const formEngineService = new FormEngineService(appConfig);
-const dataContextFactory = new DataContextFactory(new PlatformDataService(appConfig), processService, dataDecryptor, referenceGenerator);
-const translator = new FormTranslator(new FormEngineService(appConfig), dataContextFactory, dataDecryptor);
-
+const platformDataService = new PlatformDataService(appConfig);
+const integrityLeadService = new IntegrityLeadService(platformDataService);
+const dataContextFactory = new DataContextFactory(
+    new PlatformDataService(appConfig),
+    processService,
+    dataDecryptor,
+    referenceGenerator,
+    integrityLeadService
+);
+const translator = new FormTranslator(
+    new FormEngineService(appConfig),
+    dataContextFactory,
+    dataDecryptor
+);
 const formTranslateController = new FormTranslateController(translator, processService);
 const workflowTranslatorController = new WorkflowTranslationController(processService, translator);
 Tracing.correlationId = () => "CorrelationId";


### PR DESCRIPTION
Created `IntegrityLeadService` which matches a list of integrity leads with the team of a user to return the emails of the integrity leads for that user.

It does this by finding possible teams for the branch for the team of the user then filters the list of integrity leads by these teams and returns the emails of the resulting integrity leads.

Also added and updated unit tests.

I've tested this locally and I can see the integrity lead emails displayed in the page.