### PR TITLE
Add linemanagerDelegateEmails to extendedStaffDetailsContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Using the logged in user's credentials the service will create a data context wh
 {$.extendedStaffDetailsContext.linemanagerEmail}
 {$.extendedStaffDetailsContext.delegateEmails}
 {$.extendedStaffDetailsContext.integrityLeadEmails}
+{$.extendedStaffDetailsContext.linemanagerDelegateEmails}
 
 ```
 

--- a/src/models/ExtendedStaffDetailsContext.js
+++ b/src/models/ExtendedStaffDetailsContext.js
@@ -1,7 +1,9 @@
 class ExtendedStaffDetailsContext {
     constructor(extendedStaffDetails, integrityLeadEmail) {
-        this.linemanagerEmail = extendedStaffDetails.linemanager_email;
-        this.delegateEmails = extendedStaffDetails.delegate_email;
+        const { delegate_email, linemanager_delegate_email, linemanager_email } = extendedStaffDetails;
+        this.linemanagerEmail = linemanager_email;
+        this.delegateEmails = delegate_email;
+        this.linemanagerDelegateEmails = linemanager_delegate_email;
         if (integrityLeadEmail) {
             this.integrityLeadEmails = integrityLeadEmail;
         }

--- a/test/models/ExtendedStaffDetailsContext.test.js
+++ b/test/models/ExtendedStaffDetailsContext.test.js
@@ -1,33 +1,32 @@
-import {expect} from '../setUpTests'
+import { expect } from '../setUpTests'
 import ExtendedStaffDetailsContext from '../../src/models/ExtendedStaffDetailsContext';
 
 describe('ExtendedStaffDetailsContext', () => {
+    const extendedStaffDetails = {
+        linemanager_email: 'linemanager@homeoffice.gov.uk',
+        delegate_email: [
+            'delegate1@homeoffice.gov.uk',
+            'delegate2@homeoffice.gov.uk'
+        ],
+        linemanager_delegate_email: [
+            'linemanagerdelegate1@homeoffice.gov.uk',
+            'linemanagerdelegate2@homeoffice.gov.uk'
+        ]
+    };
+
     it('should return the correct data without the integrity lead', () => {
-            const extendedStaffDetails = {
-                linemanager_email: 'linemanager@homeoffice.gov.uk',
-                delegate_email: [
-                    'delegate1@homeoffice.gov.uk',
-                    'delegate2@homeoffice.gov.uk'
-                ]
-            };
             const extendedStaffDetailsContext = new ExtendedStaffDetailsContext(extendedStaffDetails);
 
             expect(extendedStaffDetailsContext.linemanagerEmail).to.equal(extendedStaffDetails.linemanager_email);
             expect(extendedStaffDetailsContext.delegateEmails).to.equal(extendedStaffDetails.delegate_email);
+            expect(extendedStaffDetailsContext.linemanagerDelegateEmails).to.equal(extendedStaffDetails.linemanager_delegate_email);
     });
 
     it('should return the correct data with the integrity lead', () => {
-        const extendedStaffDetails = {
-            linemanager_email: 'linemanager@homeoffice.gov.uk',
-            delegate_email: [
-                'delegate1@homeoffice.gov.uk',
-                'delegate2@homeoffice.gov.uk'
-            ]
-        };
         const integrityLeadEmail = [
             'integritylead1@homeoffice.gov.uk',
             'integritylead2@homeoffice.gov.uk'
-        ]
+        ];
         const extendedStaffDetailsContext = new ExtendedStaffDetailsContext(extendedStaffDetails, integrityLeadEmail);
 
         expect(extendedStaffDetailsContext.integrityLeadEmails).to.equal(integrityLeadEmail);


### PR DESCRIPTION
Added `linemanagerDelegateEmails` to `extendedStaffDetailsContext` so we can set the delegate of the user's line manager in the Man Dec process.

Also updated unit tests.