### PR TITLE
CO-1083 -     Both OAD and Border Systems integrity leads are receiving the same second review tasks

### DIFF
--- a/src/services/IntegrityLeadService.js
+++ b/src/services/IntegrityLeadService.js
@@ -1,14 +1,17 @@
 class IntegrityLeadService {
   constructor(platformDataService) {
     this.platformDataService = platformDataService;
+    this.fallbackTeamList = ['bd92915e-9192-414a-93af-988fa201d551'];
+    this.filterFields = ['branchid', 'directorateid', 'departmentid'];
   }
 
   async getEmails(staffTeamId, headers) {
     const teams = await this.platformDataService.getTeams(headers);
-    const staffTeam = this.staffTeam(teams, staffTeamId);
-    const branchTeamIds = this.branchTeamIds(teams, staffTeam.branchid);
     const integrityLeads = await this.platformDataService.getIntegrityLeads(headers);
-    return this.emails(integrityLeads, branchTeamIds);
+    const staffTeam = this.staffTeam(teams, staffTeamId);
+    let teamIds = this.filterTeamsById(teams, staffTeam);
+    teamIds = this.fallbackTeamIds(teamIds);
+    return this.emails(integrityLeads, teamIds);
   }
 
   staffTeam(teams, staffTeamId) {
@@ -16,15 +19,32 @@ class IntegrityLeadService {
       .filter(team => team.id === staffTeamId)[0];
   }
 
-  branchTeamIds(teams, staffBranchId) {
+  filterTeams(teams, matchField, staffFieldValue) {
     return teams
-      .filter(team => team.branchid === staffBranchId)
+      .filter(team => team[matchField] !== null)
+      .filter(team => team[matchField] === staffFieldValue)
       .map(team => team.id);
   }
 
-  emails(integrityLeads, branchTeamIds) {
+  filterTeamsById(teams, staffTeam) {
+    let teamIds = [];
+
+    this.filterFields.forEach(field => {
+      if (teamIds.length === 0) {
+        teamIds = this.filterTeams(teams, field, staffTeam[field]);
+      }
+    });
+
+    return teamIds;
+  }
+
+  fallbackTeamIds(teamIds) {
+    return teamIds.length > 0 ? teamIds : this.fallbackTeamList;
+  }
+
+  emails(integrityLeads, teamIds) {
     return integrityLeads
-      .filter(integrityLead => branchTeamIds.includes(integrityLead.defaultteamid))
+      .filter(integrityLead => teamIds.includes(integrityLead.defaultteamid))
       .map(integrityLead => integrityLead.email)
       .join();
   }

--- a/test/controllers/formDataByIdAndLiveQuery.test.js
+++ b/test/controllers/formDataByIdAndLiveQuery.test.js
@@ -1,16 +1,14 @@
-
 import nock from 'nock';
 import httpMocks from 'node-mocks-http';
-import * as forms from '../forms'
-import {expect, formTranslateController} from '../setUpTests'
-import sinon from "sinon";
+import { expect, formTranslateController } from '../setUpTests'
 import uuid4 from 'uuid';
+import * as forms from '../forms'
 
 describe('Form Data Resolve Controller with UUID and live === 1', () => {
     beforeEach(() => {
         nock('http://localhost:9001')
             .post('/v1/rpc/staffdetails', {
-                argstaffemail: "email"
+                argstaffemail: 'email'
             })
             .reply(200, [{
                 staffid: 'abc-123',
@@ -55,13 +53,13 @@ describe('Form Data Resolve Controller with UUID and live === 1', () => {
             kauth: {
                 grant: {
                     access_token: {
-                        token: "test-token",
+                        token: 'test-token',
                         content: {
-                            session_state: "session_id",
-                            email: "email",
-                            preferred_username: "test",
-                            given_name: "testgivenname",
-                            family_name: "testfamilyname"
+                            session_state: 'session_id',
+                            email: 'email',
+                            preferred_username: 'test',
+                            given_name: 'testgivenname',
+                            family_name: 'testfamilyname'
                         }
                     }
 
@@ -70,7 +68,6 @@ describe('Form Data Resolve Controller with UUID and live === 1', () => {
         });
 
         const response = await formTranslateController.getForm(request);
-        expect(response.name).to.equal("simpleForm");
+        expect(response.name).to.equal('simpleForm');
     });
-
 });

--- a/test/services/IntegrityLeadService.test.js
+++ b/test/services/IntegrityLeadService.test.js
@@ -6,18 +6,9 @@ import PlatformDataService from '../../src/services/PlatformDataService';
 describe('IntegrityLeadService', () => {
   let platformDataService;
   let integrityLeads;
+  let teams;
 
   const staffTeamId = '15a13c2a-fa63-4437-b4b0-d6b070e9c17e';
-  const teams = [{
-    id: staffTeamId,
-    branchid: 11
-  }, {
-    id: '444e92aa-16e6-41fb-9642-783532f4dd84',
-    branchid: 12
-  }, {
-    id: 'bfb30c46-e7fa-4716-81b7-7687eef2c312',
-    branchid: 12
-  }];
 
   beforeEach(() => {
     platformDataService = sinon.createStubInstance(PlatformDataService);
@@ -34,6 +25,16 @@ describe('IntegrityLeadService', () => {
     }, {
       email: 'integritylead3@homeoffice.gov.uk',
       defaultteamid: '9f4bebae-ffd1-4a31-9cfd-2108d3a1423f',
+    }];
+    teams = [{
+      id: staffTeamId,
+      branchid: 11
+    }, {
+      id: '444e92aa-16e6-41fb-9642-783532f4dd84',
+      branchid: 12
+    }, {
+      id: 'bfb30c46-e7fa-4716-81b7-7687eef2c312',
+      branchid: 12
     }];
   });
 
@@ -76,12 +77,12 @@ describe('IntegrityLeadService', () => {
     });
   });
 
-  describe('branchTeamIds', () => {
+  describe('filterTeams', () => {
     it('should return the correct teams for a branch', () => {
       const integrityLeadService = new IntegrityLeadService(platformDataService);
-      const branchTeamIds = integrityLeadService.branchTeamIds(teams, 12);
+      const teamIds = integrityLeadService.filterTeams(teams, 'branchid', 12);
 
-      expect(branchTeamIds).toEqual([
+      expect(teamIds).toEqual([
         '444e92aa-16e6-41fb-9642-783532f4dd84',
         'bfb30c46-e7fa-4716-81b7-7687eef2c312'
       ]);
@@ -89,9 +90,124 @@ describe('IntegrityLeadService', () => {
 
     it('should return an empty array when teams cannot be found for a branch', () => {
       const integrityLeadService = new IntegrityLeadService(platformDataService);
-      const branchTeamIds = integrityLeadService.branchTeamIds(teams, 21);
+      const teamIds = integrityLeadService.filterTeams(teams, 'branchid', 21);
 
-      expect(branchTeamIds).toEqual([]);
+      expect(teamIds).toEqual([]);
+    });
+
+    it('should not return a match when both team branch id and the staff branch id are null', () => {
+      teams[2].branchid = null;
+
+      const integrityLeadService = new IntegrityLeadService(platformDataService);
+      const teamIds = integrityLeadService.filterTeams(teams, 'branchid', null);
+
+      expect(teamIds).toEqual([]);
+    });
+  });
+
+  describe('filterTeamsById', () => {
+    it('should return the correct teams filtered by branch when given a branch, directorate and department', () => {
+      teams = [{
+        id: staffTeamId,
+        branchid: 11,
+        directorateid: 12,
+        departmentid: 17
+      }, {
+        id: '2af51406-a1c2-4c2d-8475-462564ada449',
+        branchid: 11,
+        directorateid: 14,
+        departmentid: 12
+      }, {
+        id: '444e92aa-16e6-41fb-9642-783532f4dd84',
+        branchid: 12,
+        directorateid: 16,
+        departmentid: 18
+      }, {
+        id: 'bfb30c46-e7fa-4716-81b7-7687eef2c312',
+        branchid: 12,
+        directorateid: 16,
+        departmentid: 18
+      }];
+
+      const integrityLeadService = new IntegrityLeadService(platformDataService);
+      const teamIds = integrityLeadService.filterTeamsById(teams, { branchid: 12 });
+
+      expect(teamIds).toEqual([
+        '444e92aa-16e6-41fb-9642-783532f4dd84',
+        'bfb30c46-e7fa-4716-81b7-7687eef2c312'
+      ]);
+    });
+
+    it('should return the correct teams filtered by directorate when not given a branch', () => {
+      teams = [{
+        id: staffTeamId,
+        branchid: null,
+        directorateid: 14
+      }, {
+        id: '444e92aa-16e6-41fb-9642-783532f4dd84',
+        branchid: null,
+        directorateid: 16
+      }, {
+        id: 'bfb30c46-e7fa-4716-81b7-7687eef2c312',
+        branchid: null,
+        directorateid: 16
+      }];
+
+      const integrityLeadService = new IntegrityLeadService(platformDataService);
+      const teamIds = integrityLeadService.filterTeamsById(teams, { directorateid: 16 });
+
+      expect(teamIds).toEqual([
+        '444e92aa-16e6-41fb-9642-783532f4dd84',
+        'bfb30c46-e7fa-4716-81b7-7687eef2c312'
+      ]);
+    });
+
+    it('should return the correct teams filtered by department when not given a branch or directorate', () => {
+      teams = [{
+        id: staffTeamId,
+        branchid: null,
+        directorateid: null,
+        departmentid: 17
+      }, {
+        id: '444e92aa-16e6-41fb-9642-783532f4dd84',
+        branchid: null,
+        directorateid: null,
+        departmentid: 18
+      }, {
+        id: 'bfb30c46-e7fa-4716-81b7-7687eef2c312',
+        branchid: null,
+        directorateid: null,
+        departmentid: 18
+      }];
+
+      const integrityLeadService = new IntegrityLeadService(platformDataService);
+      const teamIds = integrityLeadService.filterTeamsById(teams, { departmentid: 18 });
+
+      expect(teamIds).toEqual([
+        '444e92aa-16e6-41fb-9642-783532f4dd84',
+        'bfb30c46-e7fa-4716-81b7-7687eef2c312'
+      ]);
+    });
+  });
+
+  describe('fallbackTeamIds', () => {
+    it('should return the team ids when given team ids', () => {
+      const teamIds = [
+        '444e92aa-16e6-41fb-9642-783532f4dd84',
+        'bfb30c46-e7fa-4716-81b7-7687eef2c312'
+      ];
+      const integrityLeadService = new IntegrityLeadService(platformDataService);
+      const ids = integrityLeadService.fallbackTeamIds(teamIds);
+
+      expect(ids).toEqual(teamIds);
+    });
+
+    it('should return the fallback team id when not given team ids', () => {
+      const teamIds = [];
+      const integrityLeadService = new IntegrityLeadService(platformDataService);
+      const ids = integrityLeadService.fallbackTeamIds(teamIds);
+
+      expect(ids).toEqual(integrityLeadService.fallbackTeamList);
     });
   });
 
@@ -104,9 +220,9 @@ describe('IntegrityLeadService', () => {
     });
 
     it('should return an empty string when integrity leads cannot be found', () => {
-      const branchTeamIds = ['2d97b103-67d3-46f9-8d1f-d7be8f90f2ec'];
+      const teamIds = ['2d97b103-67d3-46f9-8d1f-d7be8f90f2ec'];
       const integrityLeadService = new IntegrityLeadService(platformDataService);
-      const emails = integrityLeadService.emails(integrityLeads, branchTeamIds);
+      const emails = integrityLeadService.emails(integrityLeads, teamIds);
 
       expect(emails).toEqual('');
     });


### PR DESCRIPTION
Previously we were getting the integrity leads for a user based on the `branchid` of the user's team matching the `branchid` of the integrity lead's team.

However:

- some teams don't have a `branchid` so in this case we need to match the `directorateid` of the user's team with the `directorateid` of the integrity lead's team.

- some teams don't have a `directorateid` so in this case we need to match the `departmentid` of the user's team with the `departmentid` of the integrity lead's team.

- some teams don't have a `departmentid` so the fallback is to match these users to OAD.

A second issue was that if the `branchid` of both the user's team and the integrity lead's team was `null` then these would match so this has been fixed by filtering out teams that have a `branchid` with a `null` value before the matching is done.